### PR TITLE
Changed text visiblity according to theme

### DIFF
--- a/client/src/components/Landing/HomePage.jsx
+++ b/client/src/components/Landing/HomePage.jsx
@@ -18,13 +18,13 @@ const HomePage = () => {
     <div className= {`max-w-full overflow-x-hidden ${isDarkMode ? 'bg-newgreen text-white':''}`}>
       <div className= {`flex flex-col justify-between items-center ${isDarkMode ? 'bg-newgreen text-white':'bg-white'} min-h-screen max-w-100vw md:w-full sm:flex-row`} >
   <div className=" text-left max-w-3xl flex flex-col justify-center p-8 mt-6 sm:mr-11 sm:ml-3">
-    <h2 className="uppercase text-sm font-semibold text-gray-700 mb-2">
+    <h2 className={`uppercase text-sm font-semibold ${isDarkMode ? 'text-gray-300' : 'text-gray-700'} mb-2`}>
             10x Webinar Value & Repurpose Content with AI
           </h2>
           <h1 className={`text-5xl font-bold ${isDarkMode ? 'bg-newgreen text-white':' text-gray-800'} mb-6 sm:w-96 `}>
             Webinar software for the modern marketer
           </h1>
-          <p className="text-lg text-gray-700 mb-8">
+          <p className={`text-lg ${isDarkMode ? 'text-gray-300' : 'text-gray-700'} mb-8`}>
             Seamlessly Design, Host, and Repurpose Company Town
           </p>
           <div className="flex space-x-4">

--- a/client/src/components/auth/expert/ExpertForget.jsx
+++ b/client/src/components/auth/expert/ExpertForget.jsx
@@ -50,7 +50,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.email}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <input
               type="password"
@@ -59,7 +59,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.current_password}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <input
               type="password"
@@ -68,7 +68,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.new_password}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <input
               type="password"
@@ -77,7 +77,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.confirm_new_password}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <button
               type="submit"

--- a/client/src/components/auth/expert/ExpertLogin.jsx
+++ b/client/src/components/auth/expert/ExpertLogin.jsx
@@ -97,7 +97,7 @@ const ExpertLogin = () => {
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3, duration: 0.8 }}
           >
-            <h1 className="text-4xl font-[serif] mb-5">Expert login</h1>
+            <h1 className={`${isDarkMode ? 'text-white' : 'text-black'} text-4xl font-[serif] mb-5`}>Expert login</h1>
             <input
               type="email"
               placeholder="Email"
@@ -131,7 +131,7 @@ const ExpertLogin = () => {
             </div>
             <a
               href="/expertforget"
-              className="text-md font-medium text-gray-950 hover:text-gray-700"
+              className={`text-md font-medium text-gray-950 hover:text-gray-700 ${isDarkMode ? 'text-white hover:text-gray-300' : 'text-black'}`}
             >
               Forget password?
             </a>

--- a/client/src/components/auth/student/StudentForget.jsx
+++ b/client/src/components/auth/student/StudentForget.jsx
@@ -50,7 +50,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.email}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <input
               type="password"
@@ -59,7 +59,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.current_password}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <input
               type="password"
@@ -68,7 +68,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.new_password}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <input
               type="password"
@@ -77,7 +77,7 @@ const StudentForget = () => {
               onChange={handleChange}
               value={inputs.confirm_new_password}
               required
-              className="w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
+              className="text-black w-[370px] py-4 px-6 mb-4 text-sm bg-gray-100 border border-gray-300 rounded-lg outline-none transition-all focus:border-teal-500 focus:ring focus:ring-teal-500 focus:ring-opacity-50"
             />
             <button type="submit" className="mt-4 bg-teal-500 text-white font-bold text-md py-3 px-8 rounded-full transition-all hover:bg-teal-600">
               Submit

--- a/client/src/components/auth/student/StudentLogin.jsx
+++ b/client/src/components/auth/student/StudentLogin.jsx
@@ -95,7 +95,7 @@ const StudentLogin = () => {
             animate={{ opacity: 1 }}
             transition={{ delay: 0.3, duration: 0.8 }}
           >
-            <h1 className="text-3xl sm:text-4xl font-[serif] mb-5">Student login</h1>
+            <h1 className={`${isDarkMode ? 'text-white' : 'text-black'} text-3xl sm:text-4xl font-[serif] mb-5`}>Student login</h1>
             <input
               type="email"
               placeholder="Email"


### PR DESCRIPTION
Fixes issue #227 

Added styles to the text in required pages to make the text visible in dark mode.
Changed the text color to white in home page:
![Screenshot 2024-08-01 223419](https://github.com/user-attachments/assets/8e4f6e4d-9dbe-41fb-baee-b3d30fb2926f)

Made the text color in text fields of forget password page to black:
![Screenshot 2024-08-01 223503](https://github.com/user-attachments/assets/08240660-32a8-4dc2-b436-d58044e83147)

Made the headings of Student login and expert login pages to white color in dark theme:
![Screenshot 2024-08-01 223526](https://github.com/user-attachments/assets/a9604990-581e-40d5-9955-3d0d73562473)
![Screenshot 2024-08-01 223549](https://github.com/user-attachments/assets/12b64d38-96b6-4b71-8760-e94cf04b8f58)

Please check it and let me know if any changes to be made, Thank you.
